### PR TITLE
Move CORS headers from being set by default but to only when requested

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ locals {
   vcl_remove_cookies_headers  = file("${path.module}/vcl/remove_cookies_headers.vcl")
   vcl_remove_response_headers = file("${path.module}/vcl/remove_response_headers.vcl")
   vcl_segmented_caching       = file("${path.module}/vcl/segmented_caching.vcl")
+  vcl_cors_headers            = file("${path.module}/vcl/add_cors_headers.vcl")
 }
 
 resource "fastly_service_vcl" "files_service" {
@@ -112,6 +113,13 @@ resource "fastly_service_vcl" "files_service" {
     name     = "Remove headers from origin response"
     content  = local.vcl_remove_response_headers
     type     = "fetch"
+    priority = 100
+  }
+
+  snippet {
+    name     = "Add CORS headers if necessary"
+    content  = local.vcl_cors_headers
+    type     = "deliver"
     priority = 100
   }
 

--- a/vcl/add_cors_headers.vcl
+++ b/vcl/add_cors_headers.vcl
@@ -1,0 +1,6 @@
+# Set CORS headers only if client sends the Origin Header and only if we are executing on the edge
+if ( fastly.ff.visits_this_service == 0 && req.http.Origin ) {
+  set beresp.http.Access-Control-Allow-Origin = "*";
+  set beresp.http.Access-Control-Allow-Methods = "GET";
+  set beresp.http.Access-Control-Allow-Headers = "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type";
+} 

--- a/vcl/remove_response_headers.vcl
+++ b/vcl/remove_response_headers.vcl
@@ -5,7 +5,11 @@ unset beresp.http.x-amz-server-side-encryption;
 unset beresp.http.x-amz-bucket-region;
 unset beresp.http.x-amzn-requestid;
 
-set beresp.http.Access-Control-Allow-Origin = "*";
-set beresp.http.Access-Control-Allow-Methods = "GET";
-set beresp.http.Access-Control-Allow-Headers = "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type";
+# Set CORS headers only if client sends the Origin Header
+if ( req.http.Origin ) {
+  set beresp.http.Access-Control-Allow-Origin = "*";
+  set beresp.http.Access-Control-Allow-Methods = "GET";
+  set beresp.http.Access-Control-Allow-Headers = "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type";
+} 
+
 set beresp.http.Cache-Control = "public, max-age=315576000, immutable";

--- a/vcl/remove_response_headers.vcl
+++ b/vcl/remove_response_headers.vcl
@@ -5,11 +5,5 @@ unset beresp.http.x-amz-server-side-encryption;
 unset beresp.http.x-amz-bucket-region;
 unset beresp.http.x-amzn-requestid;
 
-# Set CORS headers only if client sends the Origin Header
-if ( req.http.Origin ) {
-  set beresp.http.Access-Control-Allow-Origin = "*";
-  set beresp.http.Access-Control-Allow-Methods = "GET";
-  set beresp.http.Access-Control-Allow-Headers = "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type";
-} 
-
+# Set the Caching policy for all files
 set beresp.http.Cache-Control = "public, max-age=315576000, immutable";


### PR DESCRIPTION
It's not a huge thing but may save 100 byte per request. Only set CORS headers when client/browser explicitly asks for them by setting the Origin request header. 