### PR TITLE
Couple different improvements

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
   ssl_hostname = var.ssl_hostname != "" ? var.ssl_hostname : var.hostname
 
   vcl_exoscale_forward        = templatefile("${path.module}/vcl/exoscale_forward.vcl", { hostname = replace(var.app_hostname, ".", "-") })
-  vcl_remove_cookies_headers  = file("${path.module}/vcl/remove_cookies_headers.vcl")
+  vcl_recv_various_fixups     = file("${path.module}/vcl/recv_misc_fixups.vcl")
   vcl_remove_response_headers = file("${path.module}/vcl/remove_response_headers.vcl")
   vcl_segmented_caching       = file("${path.module}/vcl/segmented_caching.vcl")
 }
@@ -95,8 +95,8 @@ resource "fastly_service_vcl" "files_service" {
   }
 
   snippet {
-    name     = "Remove cookies and headers from request"
-    content  = local.vcl_remove_cookies_headers
+    name     = "Recv Various Fixups"
+    content  = local.vcl_recv_various_fixups
     type     = "recv"
     priority = 100
   }

--- a/vcl/exoscale_forward.vcl
+++ b/vcl/exoscale_forward.vcl
@@ -1,9 +1,3 @@
 if (req.method == "GET" && !req.backend.is_shield) {
   set bereq.url = "/${hostname}" + req.url;
 }
-
-if (req.url.ext ~ "(?i)^(jpe?g|png|gif|mp4|mp3|gz|svg|avif|webp)$") {
-  
-} else {
-  error 404;
-}

--- a/vcl/recv_misc_fixups.vcl
+++ b/vcl/recv_misc_fixups.vcl
@@ -1,0 +1,18 @@
+# Remove all query arguments to increase cache hit ratios. This may need to be changed/undone in case Image Opto is used
+set req.url = querystring.remove(req.url);
+
+# Block any HTTP verbs on on the approved list. No need to forward that back to the origin
+if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+  error 404;
+}
+
+# We only serve static media files. Block everything else
+if (req.url.ext ~ "(?i)^(jpe?g|png|gif|mp4|mp3|gz|svg|avif|webp)$") {
+
+} else {
+  error 404;
+}
+
+# Remove all headers we don't care to be passing around. It does not remove protected headers. More details
+# https://developer.fastly.com/reference/vcl/functions/headers/header-filter-except/
+header.filter_except(req, "Accept-Encoding");

--- a/vcl/remove_cookies_headers.vcl
+++ b/vcl/remove_cookies_headers.vcl
@@ -1,1 +1,0 @@
-unset req.http.Cookie;


### PR DESCRIPTION
- Move returning 404s on non media assets to a recv snippet called recv_various_fixups
- Add couple security enhancements where we block any HTTP verbs that are not on the approved list
- Clean up all the request headers to avoid header stuffing. This obviates the sending of the Cookie header. Your backend will thank you